### PR TITLE
add AimDB - async in-memory data bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [IoTDL ★ 9 ⧗ 8](https://github.com/dpjanes/iotdb-iotql) - an SQL-like language for the IoT.
 * [node-iotdb ★ 19 ⧗ 61](https://github.com/dpjanes/node-iotdb) - Easily control the Internet of Things using Semantics.
 * [HStreamDB ★ 172](https://github.com/hstreamdb/hstream) - The streaming database built for IoT data storage and real-time processing.
-* [AimDB ★ 2](https://github.com/aimdb-dev/aimdb): An async, in-memory data bridge that syncs records across microcontrollers, edge gateways and cloud instances. Define once, stream and sync everywhere.
+* [AimDB ★ 2](https://github.com/aimdb-dev/aimdb) - An async, in-memory data bridge that syncs records across microcontrollers, edge gateways and cloud instances. Define once, stream and sync everywhere.
 
 ## Security
 


### PR DESCRIPTION
Added AimDB as an async, in-memory data bridge for syncing records across edge devices and cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added AimDB to the README Storage section with a concise description: "An async, in-memory data bridge that syncs records across microcontrollers, edge gateways and cloud instances. Define once, stream and sync everywhere." This makes AimDB discoverable as a storage option for async in-memory scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->