### PR TITLE
Add boto3-refresh-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ for embedded systems (IoT in mind).
 * **[Sonoff-Tasmota ★ 4869 ⧗ 0](https://github.com/arendst/Sonoff-Tasmota)** - Provide ESP8266 based itead Sonoff with Web, MQTT and OTA firmware using Arduino IDE.
 * [tinyVP ★ 12 ⧗ 48](https://github.com/lyegoshin/tinyVP) - is a very small and lean hypervisor using MIPS R5 hardware VZ option
 * [vorto ★ 32 ⧗ 3](https://github.com/eclipse/vorto) - is a toolset that lets you describe devices using a simple language and share these descriptions, so-called Information Models, in a centralized Vorto Repository.
-* [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) - A drop-in replacement for `boto3.session.Session` for automatically refreshing temporary AWS credentials for AWS IoT Core (X.509).
+* [boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) - A drop-in replacement for `boto3.session.Session` for automatically refreshing temporary AWS credentials from the AWS IoT Core credential provider (using an X.509 certificate).
 
 ## Language
 


### PR DESCRIPTION
Hello!

[boto3-refresh-session](https://github.com/michaelthomasletts/boto3-refresh-session) is a simple Python package for automatically refreshing temporary AWS security credentials in the AWS Python SDK (boto3). 

For IoT developers looking to access AWS services and resources with the security of temporary security credentials from the IoT credential provider, this has historically been a major pain point for them. boto3 does not refresh these particular temporary security credentials automatically, and acquiring them in the first place can be a challenge. Therefore, adding IoT support into boto3-refresh-session seemed like a natural fit given the package's raison d'être. 

Specifically, boto3-refresh-session accommodates X.509 certificates and PKCS#11 libraries. It also includes an MQTT method. However, the core advantage of the package is it allows IoT developers to access AWS IoT core securely via IAM role alias affiliated with a particular `thing`. The approach employed in this library was heavily inspired and personally encouraged by Gavin Adams at AWS through his work in [this repository](https://github.com/awslabs/aws-iot-core-credential-provider-session-helper). Although this project is highly niche, I am certain it will help people personally experiencing the above-mentioned issue, due to the lack of support offered by the Python AWS SDK (boto3).

Thank you for your time and consideration!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added entries to the README’s "Others" section documenting boto3-refresh-session (two identical bullets were added), so the project README now references boto3-refresh-session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->