### PR TITLE
Add PiSpot-Show to Low Level section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [Soletta ★ 96 ⧗ 2](https://github.com/solettaproject/soletta) - Soletta Project is a framework for making IoT devices. With Soletta Project's libraries developers can easily write software for devices that control actuators/sensors and communicate using standard technologies.
 * [SPIFFS ★ 174 ⧗ 0](https://github.com/pellepl/spiffs) - Wear-leveled SPI flash file system for embedded devices.
 * [SUSI ★ 13 ⧗ 150](https://github.com/webvariants/susi) - is an application framework to build interfaces for arbitrary systems.
+* [PiSpot-Show](https://github.com/GeiserX/PiSpot-Show) - a Raspberry Pi captive portal that creates a WiFi hotspot displaying a customizable web page to connected users using hostapd, dnsmasq, and nginx.
 * [SwiftyGPIO ★ 407 ⧗ 1](https://github.com/uraimo/SwiftyGPIO) - a Swift library to interact with Linux GPIO/SPI on ARM.
 * [uIP ★ 246 ⧗ 3](https://github.com/adamdunkels/uip) - uIP is a very small implementation of the TCP/IP stack.
 * [WifiDog ★ 291 ⧗ 1](https://github.com/wifidog/wifidog-gateway) - a complete and embeddable captive portal solution for wireless community groups or individuals.


### PR DESCRIPTION
## Summary

- Adds [PiSpot-Show](https://github.com/GeiserX/PiSpot-Show) to the **Low Level** section, alongside WifiDog (another captive portal project).
- PiSpot-Show is a Raspberry Pi captive portal that creates a WiFi hotspot displaying a customizable web page to connected users using hostapd, dnsmasq, and nginx.
- Licensed under MIT. Useful for events, marketing, and education scenarios.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Raspberry Pi captive portal project reference to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->