### PR TITLE
Add PiSpot Watch and PiSpot Show to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,10 @@ Layered architecture of JTAG interface and TAP support
 * [Intel Galileo](http://www.arduino.cc/en/ArduinoCertified/IntelGalileo) - Galileo is a microcontroller board based on the Intel® Quark SoC X1000 Application Processor, a 32-bit Intel Pentium-class system on a chip
 * [Microduino](https://www.microduino.cc/) - Microduino is about the size of a quarter and less than half the size of the original Arduino board.
 * [NodeMCU](http://www.nodemcu.com/) -  a firmware based on ESP8266 wifi-soc.
+* [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Raspberry Pi WiFi voucher display system with weather integration and PiJuice battery management.
+* [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable Raspberry Pi Zero smartwatch with e-ink display for generating WiFi voucher codes on demand.
 * [Powerduino ★ 53 ⧗ 102](https://github.com/dekuNukem/Powerduino) - A fully programmable power strip with energy monitoring and wireless connectivity.
 * [PULPino ★ 201 ⧗ 0](https://github.com/pulp-platform/pulpino) - PULPino is an open-source microcontroller system, based on a small 32-bit RISC-V core developed at ETH Zurich.
-* [PiSpot Show ★ 1](https://github.com/GeiserX/PiSpot-Show) - Raspberry Pi WiFi voucher display system with weather integration and PiJuice battery management.
-* [PiSpot Watch ★ 1](https://github.com/GeiserX/PiSpot-Watch) - Software for running a PiSpot Watch, composed of a Raspberry Pi Zero and a PaPiRus Zero e-ink display.
 * [Raspberry Pi](https://www.raspberrypi.org/) - a tiny and affordable computer that you can use to learn programming through fun, practical projects
 * [SquareWear](http://rayshobby.net/sqrwear/) - An Open-Source Arduino-based Wearable Microcontroller
 * [Tessel](https://tessel.io/) - Tessel is a completely open source and community-driven IoT and robotics development. platform.


### PR DESCRIPTION
## Summary

- Add [PiSpot Show](https://github.com/GeiserX/PiSpot-Show): Raspberry Pi WiFi voucher display system with weather integration and PiJuice battery management.
- Add [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch): Software for running a PiSpot Watch, composed of a Raspberry Pi Zero and a PaPiRus Zero e-ink display.

Both projects are open-source Raspberry Pi-based IoT hardware projects, added alphabetically to the Hardware section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two new items—PiSpot Show and PiSpot Watch—under Layered architecture (JTAG/TAP).
  * Added the same two items under Hardware Real-time Data to document their presence and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->