### PR TITLE
Add MapAtlas to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 
 ## APIs
 
+* [MapAtlas](https://mapatlas.eu/) - Developer-first mapping API providing geocoding, routing, map tiles, and search/autocomplete for IoT devices and connected applications.
 * [OGC SensorThings API ★ 21 ⧗ 15](https://github.com/opengeospatial/sensorthings) - The OGC SensorThings API is an OGC standard specification for providing an open and unified way to interconnect IoT devices, data, and applications over the Web
 * [OpenCage](https://opencagedata.com/) - provide a reverse geocoding API based on open data for high volume conversion of device coordinates (lat,lon) into useful location information (address, timezone, etc).
 * [Qeo Tinq ★ 6 ⧗ 392](https://github.com/brunodebus/tinq-core) - Tinq is completely based on the Qeo publish/subscribe framework produced by Technicolor as explained in the license section.


### PR DESCRIPTION
Adding MapAtlas to the APIs section.

MapAtlas provides geocoding, routing, map tiles, and search/autocomplete via REST API. Useful for IoT devices needing location services. EU-hosted, GDPR compliant, free tier available.

Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V., the company behind MapAtlas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MapAtlas API to the available APIs list, offering mapping, geocoding, routing, map tiles, search, and autocomplete capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->