### PR TITLE
Add AutoPi project to the list of IoT platforms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Layered architecture of JTAG interface and TAP support
 * [APixel ★ 8 ⧗ 31](https://github.com/AprilBrother/APixel) - APixel is a combination of a ESP8266 dev board with a WS2812B (Addressable RGB) LED all in one.
 * [Arduino](http://www.arduino.cc/) - open-source electronics platform based on easy-to-use hardware and software.
 * [Arduino ZERO](https://www.arduino.cc/en/Main/ArduinoBoardZero) - This board aims to provide a platform for innovative projects in smart IoT devices, wearable technology, high-tech automation, crazy robotics, and much more.
+* [AutoPi](https://github.com/autopi-io/autopi-core) - Open-source core software for the AutoPi dongle, a Raspberry Pi-based OBD-II device for vehicle telematics, CAN bus data collection, and automotive IoT applications.
 * [BeagleBone](http://beagleboard.org/getting-started/) -  BeagleBone Black is a low-cost, community-supported development platform for developers and hobbyists.
 * [Bitsy Bits ★ 3 ⧗ 36](https://github.com/bitsybits/bitsybits-core) - is an IoT composite project. This means it has all parts to implement the full user experience.
 * [Carloop ★ 6 ⧗ 0](https://github.com/carloop/carloop-library) - Make apps for your car using signals from OBD-II, CAN and GPS. Publish data online using the Particle platform.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AutoPi hardware entry to the documentation, including GitHub link and description of the open-source software for the AutoPi dongle (Raspberry Pi-based OBD-II/CAN bus data collection and automotive IoT platform).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->