### PR TITLE
Add Homebridge Blink Security and SmartRent plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Layered architecture of JTAG interface and TAP support
 * **[home-assistant ★ 3237 ⧗ 0](https://github.com/balloob/home-assistant)** - Open-source home automation platform running on Python 3
 * [home.pi ★ 145 ⧗ 1](https://github.com/denschu/home.pi) - Home Automation with AngularJS and MQTT on a Raspberry Pi
 * **[Homebridge ★ 3030 ⧗ 0](https://github.com/nfarina/homebridge)** - Homebridge is a lightweight NodeJS server you can run on your home network that emulates the iOS HomeKit API.
+* [homebridge-blink-security](https://github.com/BitWise-0x/homebridge-blink-security) - Homebridge plugin for Blink cameras, doorbells, and sirens with live streaming, arm/disarm, and motion detection via Apple HomeKit.
+* [homebridge-smartrent](https://github.com/BitWise-0x/homebridge-smartrent) - Homebridge plugin for SmartRent locks, thermostats, leak sensors, and switches with real-time WebSocket updates via Apple HomeKit.
 * [Lumos ★ 70 ⧗ 1](https://github.com/jonathanrjpereira/Lumos) - aims to change that by pairing with WiFi and uses Machine Learning to adjust the light to match your sleep schedule.
 * **[Magic Mirror ★ 503 ⧗ 0](https://github.com/MicrosoftEdge/magic-mirror-demo)** - A ⚡Magic Mirror⚡ powered by a UWP Hosted Web App.
 * [Mozilla Smart Home ★ 4 ⧗ 8](https://github.com/mozilla/smarthome.iot) - offers a middle ground between "in a box" solutions like Apple Homekit and DIY solutions like Raspberry Pi


### PR DESCRIPTION
## Summary
Adds two **Homebridge Verified** plugins to the Home Automation section, placed after the existing Homebridge entry:

- **[homebridge-blink-security](https://github.com/BitWise-0x/homebridge-blink-security)** — Blink cameras, doorbells, and sirens with live streaming, arm/disarm, and motion detection via Apple HomeKit
  - npm: [`@jackietreeh0rn/homebridge-blink-security`](https://www.npmjs.com/package/@jackietreeh0rn/homebridge-blink-security) (last published 2026-03-05)
- **[homebridge-smartrent](https://github.com/BitWise-0x/homebridge-smartrent)** — SmartRent locks, thermostats, leak sensors, and switches with real-time WebSocket updates via Apple HomeKit
  - npm: [`@jackietreeh0rn/homebridge-smartrent`](https://www.npmjs.com/package/@jackietreeh0rn/homebridge-smartrent) (last published 2025-08-31)

Both are listed on the [Homebridge Verified Plugins](https://github.com/homebridge/plugins/wiki/Verified-Plugins) page and actively maintained.