### PR TITLE
Add data-act-iot-kit (EU Data Act Art. 4-5 reference impl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [nShield ★ 66 ⧗ 35](https://github.com/fnzv/nShield) - An Easy and Simple Anti-DDoS solution for VPS,Dedicated Servers and IoT devices based on iptables.
 * [Scanners-Box ★ 424 ⧗ 0](https://github.com/We5ter/Scanners-Box) - the toolbox of open source scanners.
 * [trezor-crypto ★ 94 ⧗ 1](https://github.com/trezor/trezor-crypto) - 📙 Heavily optimized cryptography algorithms for embedded devices.
+* [data-act-iot-kit](https://github.com/plusultra-tools/data-act-iot-kit) - EU Data Act Art. 4-5 reference implementation. Drop-in user-data-access HTTP endpoint for connected products, with verbatim-cited compliance manifest. Targets the 2026-09-11 access-by-design obligation.
 
 ## OS
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [nShield ★ 66 ⧗ 35](https://github.com/fnzv/nShield) - An Easy and Simple Anti-DDoS solution for VPS,Dedicated Servers and IoT devices based on iptables.
 * [Scanners-Box ★ 424 ⧗ 0](https://github.com/We5ter/Scanners-Box) - the toolbox of open source scanners.
 * [trezor-crypto ★ 94 ⧗ 1](https://github.com/trezor/trezor-crypto) - 📙 Heavily optimized cryptography algorithms for embedded devices.
-* [data-act-iot-kit](https://github.com/plusultra-tools/data-act-iot-kit) - EU Data Act Art. 4-5 reference implementation. Drop-in user-data-access HTTP endpoint for connected products, with verbatim-cited compliance manifest. Targets the 2026-09-11 access-by-design obligation.
+* [data-act-iot-kit](https://github.com/plusultra-tools/data-act-iot-kit) - EU Data Act Art. 4-5 reference implementation. Drop-in user-data-access HTTP endpoint for connected products, with verbatim-cited compliance manifest. Targets the 2026-09-12 access-by-design obligation.
 
 ## OS
 


### PR DESCRIPTION
Adds [data-act-iot-kit](https://github.com/plusultra-tools/data-act-iot-kit) to the Security section.

What it is: an MIT-licensed Python reference implementation of the EU Data Act (Regulation 2023/2854) Articles 4 and 5 user-data-access obligation for connected products. The Data Act applies to NEW connected products placed on the EU market from 12 September 2026; Germany has designated the Bundesnetzagentur as supervisor with fines up to 4% of turnover.

What it does:
- Drop-in /user-data-access HTTP endpoint with access-decision engine covering Art. 4(1) user-right, Art. 4(6) trade-secret-limit, Art. 5(1) third-party-with-consent, Art. 5(11) competing-product-prohibition.
- Verbatim regulatory clause text travels with every decision.
- SHA-256 chained audit log of all access events for the Art. 4(13) audit-trail requirement.

Targets firmware and embedded teams at EU IoT manufacturers that need a compliance preflight without buying enterprise data-portability suites (BigID, Collibra). Disclosure: I am the author. 19 tests pass, ruff + mypy strict clean. Happy to revise placement or wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Security entry in the README linking to a Data Act reference implementation that documents a drop-in user-data-access HTTP endpoint and includes a quoted compliance manifest.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/awesome-iot/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->