### PR TITLE
Add ForestHub.ai under IIoT Clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [Space-Time Insight IIoT](http://www.spacetimeinsight.com/solutions/internet-of-things/) - Industrial IoT cloud (formerly go-factory.com).
 * [Thingworx](https://www.thingworx.com/platforms/industrial-connectivity/) - Industrial IoT cloud.
 * [Voice of the Machine](http://www.parker.com/portal/site/PARKER/menuitem.17c8315d31f057bc86a6c3544256d1ca/?vgnextoid=244744e25684b510VgnVCM100000e6651dacRCRD&vgnextchannel=9f45216358d55510VgnVCM100000e6651dacRCRD&vgnextfmt=) - Industrial IoT cloud (by Parker Hannifin, based on Exosite).
-* [ForestHub.ai](https://foresthub.ai) - Platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices.
+* [ForestHub.ai](https://foresthub.ai) - Embedded & edge AI agent platform for industrial devices.
 
 ## APIs
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [Space-Time Insight IIoT](http://www.spacetimeinsight.com/solutions/internet-of-things/) - Industrial IoT cloud (formerly go-factory.com).
 * [Thingworx](https://www.thingworx.com/platforms/industrial-connectivity/) - Industrial IoT cloud.
 * [Voice of the Machine](http://www.parker.com/portal/site/PARKER/menuitem.17c8315d31f057bc86a6c3544256d1ca/?vgnextoid=244744e25684b510VgnVCM100000e6651dacRCRD&vgnextchannel=9f45216358d55510VgnVCM100000e6651dacRCRD&vgnextfmt=) - Industrial IoT cloud (by Parker Hannifin, based on Exosite).
+* [ForestHub.ai](https://foresthub.ai) - Platform for building, deploying and orchestrating embedded and edge AI agents on machines, controllers and industrial edge devices.
 
 ## APIs
 


### PR DESCRIPTION
## Summary

Adds one entry to **IIoT Clouds** for [ForestHub.ai](https://foresthub.ai) — a platform for embedded and edge AI agents on industrial machines and controllers.

## Why this fits

Sits naturally alongside existing IIoT entries (Predix, Thingworx, deviceWISE) but focuses specifically on agentic workloads at the edge (visual builder, local runtime, hybrid edge-cloud orchestration) rather than data telemetry.

## Disclosure

I'm affiliated with ForestHub.ai. Happy to adjust the wording, move to a different section (Platform / Framework), or omit if you'd prefer.

Thanks for maintaining this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ForestHub.ai to the IIoT Clouds list as a new platform for building, deploying, and orchestrating embedded and edge AI agents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/awesome-iot/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->