### PR TITLE
Add Electrum to Toolkits Include Non-OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 
 Layered architecture of JTAG interface and TAP support
 
+* [Electrum ★ 4 ⧗ 1](https://github.com/yoelf22/electrum) - A structured, AI-assisted toolkit for defining hardware products that have software inside — from concept through engineering spec to presentation-ready materials in eight phases.
 * [IoT Toolkit ★ 39 ⧗ 41](https://github.com/connectIOT/iottoolkit) - Reference implementation of the smart object API
 * [iot-adk-addonkit ★ 8 ⧗ 1](https://github.com/ms-iot/iot-adk-addonkit) - Contains command line scripts for package creation and image creation process and samples for iot products based on RPi2/MBM.
 * [KinomaJS ★ 293 ⧗ 0](https://github.com/Kinoma/kinomajs) - A JavaScript runtime optimized for the applications that power IoT devices.


### PR DESCRIPTION
Adding **Electrum** to the `Toolkits Include Non-OS` section.

Electrum is an MIT-licensed Python toolkit and Claude Code skill for the product-definition phase of hardware products that contain embedded software. It walks a one-sentence idea through HW/SW boundary mapping, a full engineering system description, a 90-item gate checklist, and a LinkedIn-format PPTX/PDF carousel. Markdown templates also work without AI.

It fits this section because it's a methodology toolkit for hardware-with-firmware products, alongside existing entries like `IoT Toolkit` (reference implementation) and `macchina.io` (toolkit for embedded IoT applications). Placed alphabetically at the top (E before I).

- Format matches neighboring entries: `* [Name ★ N ⧗ M](url) - Description.`
- ★ 4 = current star count; ⧗ 1 = ~1 month since last commit.

Repo: https://github.com/yoelf22/electrum (MIT, v0.1.0 release, 7 worked examples).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Electrum toolkit entry to documentation with GitHub link and description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phodal/awesome-iot/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->