### PR TITLE
Add awtSCADA and Genesis 2 to Platform and AI sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [United Manufacturing Hub ★ 9 ⧗ 0](https://github.com/united-manufacturing-hub/united-manufacturing-hub) - The Open-Source Manufacturing App Platform (combines various open source solutions and packages them in a Helm chart, for example nodered, VerneMQ and timescaleDB)
 * [BitSCADA ★ 0 ⧗ 0](https://github.com/larionovavi-stack/bitscada) - Complete industrial SCADA/HMI system that runs from a single HTML file. Supports IEC 61850 (MMS, GOOSE, SV), OPC UA, Modbus TCP, MQTT. 53 function blocks, 65 graphic elements, Python gateway for real PLC/RTU/IED connections. Zero installation — any browser.
 * [Fuxa SCADA/HMI/Dashboard ★ 2115 ⧗ 632](https://github.com/frangoteam/FUXA) - FUXA is a web-based Process Visualization (SCADA/HMI/Dashboard) software. With FUXA you can create modern process visualizations/dashboards with individual designs for your machines/IOT application with real-time data display. Supports MQTT, OPC-UA, Modbus RTU/TCP, Siemens S7 Protocol, BACnet IP, Ethernet/IP (Allen Bradley), WebAPI
+* [awtSCADA](https://github.com/larionovavi-stack/awtscada) - Industrial SCADA/HMI system that runs from a single HTML file in any browser. Supports IEC 61850, OPC UA, Modbus TCP. 53 function blocks, 65 graphic elements. No installation required.
 
 ## IoT Clouds
 
@@ -730,6 +731,7 @@ for embedded systems (IoT in mind).
 * [libdeep](https://github.com/bashrc/libdeep) - A deep learning library for C/C++.
 * [Machinery ★ 174 ⧗ 0](https://github.com/kerberos-io/machinery) - is a low-budget video surveillance solution, that uses computer vision algorithms to detect changes, and that can trigger other devices.
 * [TensorFlow for Raspberry Pi ★ 317 ⧗ 0](https://github.com/samjabrahams/tensorflow-on-raspberry-pi) - step-by-step instructions for installing TensorFlow from source using Bazel (which is also compiled from-scratch), as well as pre-built TensorFlow binaries.
+* [Genesis 2](https://github.com/larionovavi-stack/genesis2-cascade-moe) - Cascade MoE neural network for IoT edge deployments. CPU-only inference (18ms), no GPU required, patented architecture with zero catastrophic forgetting.
 
 ## Analytics
 


### PR DESCRIPTION
## Added

### Platform section
- **awtSCADA** — Industrial SCADA/HMI system in a single HTML file. Supports IEC 61850, OPC UA, Modbus TCP. Free to use, no installation required.
  - GitHub: https://github.com/larionovavi-stack/awtscada
  - Live demo: https://scada.atwai.ru

### AI section  
- **Genesis 2** — Cascade MoE neural network designed for IoT edge. Runs on CPU only (18ms inference), patented architecture.
  - GitHub: https://github.com/larionovavi-stack/genesis2-cascade-moe

Both projects are actively maintained (2026).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added awtSCADA to the supported IoT platforms list with feature descriptions.
  * Added Genesis 2 to the supported AI platforms list with model and inference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->