### PR TITLE
Add Superhighway manufacturing & Industry 4.0 research agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [OpenCage](https://opencagedata.com/) - provide a reverse geocoding API based on open data for high volume conversion of device coordinates (lat,lon) into useful location information (address, timezone, etc).
 * [Qeo Tinq ★ 6 ⧗ 392](https://github.com/brunodebus/tinq-core) - Tinq is completely based on the Qeo publish/subscribe framework produced by Technicolor as explained in the license section.
 * [Vedika API](https://vedika.io) - Vedic astrology API with AI chatbot for IoT displays, smart mirrors, and embedded dashboards. Provides birth charts, daily horoscopes, panchang, and muhurta calculations.
+* [Superhighway](https://superhighway.walls.sh/guides/manufacturing-research-agent) - Live web search API for AI agents. Build a Python agent that researches manufacturing markets, IIoT landscapes, OEE benchmarks, and supply chain trends. Pay-per-call with USDC via x402.
 
 ## Middleware
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh/guides/manufacturing-research-agent) to the APIs section — a guide for building Python agents that research manufacturing markets, Industry 4.0/IIoT technology landscapes, OEE benchmarks, and supply chain integration using live web search. Pay-per-call USDC micro-payments via x402 (no signup required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Superhighway API to the APIs section with details on live web search capabilities and pay-per-call pricing model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->