### PR TITLE
Update ForestHub entry: add repo link + sharper description

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [Space-Time Insight IIoT](http://www.spacetimeinsight.com/solutions/internet-of-things/) - Industrial IoT cloud (formerly go-factory.com).
 * [Thingworx](https://www.thingworx.com/platforms/industrial-connectivity/) - Industrial IoT cloud.
 * [Voice of the Machine](http://www.parker.com/portal/site/PARKER/menuitem.17c8315d31f057bc86a6c3544256d1ca/?vgnextoid=244744e25684b510VgnVCM100000e6651dacRCRD&vgnextchannel=9f45216358d55510VgnVCM100000e6651dacRCRD&vgnextfmt=) - Industrial IoT cloud (by Parker Hannifin, based on Exosite).
-* [ForestHub.ai](https://foresthub.ai) - Embedded & edge AI agent platform for industrial devices.
+* [ForestHub](https://foresthub.ai) - Edge AI agent platform; its open-source runtime [edge-agents](https://github.com/ForestHubAI/edge-agents) runs AI agents offline on Linux edge gateways with local SLMs, cloud LLMs and MQTT as first-class nodes.
 
 ## APIs
 


### PR DESCRIPTION
Updates the existing ForestHub entry. Adds the open-source repository link ([ForestHubAI/edge-agents](https://github.com/ForestHubAI/edge-agents)) and a more precise one-line description. Same section and format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ForestHub entry in IIoT Clouds section to reflect its positioning as an Edge AI agent platform
  * Added reference to the edge-agents open-source runtime for deploying AI agents offline on Linux edge gateways

<!-- end of auto-generated comment: release notes by coderabbit.ai -->